### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group "com.mx.binks"
-version "3.0.0"
+version "3.0.1"
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 


### PR DESCRIPTION
contains revert of java 21 upgrade